### PR TITLE
Don't crash when using --dry-run on an upload

### DIFF
--- a/contentful/management.py
+++ b/contentful/management.py
@@ -448,7 +448,7 @@ class ContentfulEndpoint:
             response.status_code = 000
             response.text = json.dumps({
                 'method': self.method,
-                'data': data,
+                'data': None if data is None else data.decode('utf-8', errors='surrogateescape'),
                 'headers': headers,
                 'params': params
             })

--- a/contentful/test_management.py
+++ b/contentful/test_management.py
@@ -175,6 +175,18 @@ def test_stream(mocker):
     assert out['body']['params'] == {'limit': None, 'skip': None}
     assert out['operation'] == 'list-content-types'
 
+def test_stream_with_data_argument(mocker):
+    stream_file = '{"operation":"post-entry","arguments":{"space_id":"test-space","content_type":"typename","document_body": {}}}'
+
+    proc = subprocess.run(['python', './contentful/management.py', 'stream', '-', '--dry-run'], input=stream_file, universal_newlines=True, stdout=subprocess.PIPE)
+
+    out = json.loads(proc.stdout)
+
+    assert out['url'] == 'https://api.contentful.com/spaces/test-space/entries/'
+    assert out['body']['params'] == {}
+    assert out['operation'] == 'post-entry'
+    assert out['body']['data'] == '{}'
+
 def test_stream_bad_command(mocker):
     stream_file = '{"operation":"obviously-fake-command","arguments":{}}'
 


### PR DESCRIPTION
Problem: Crashes with a JSON encoding error if attempting to --dry-run a
an operation that uploads a document (e.g. put-entry, post-entry).

Solution: Binary data needs decoded before putting it into a JSON
document. While it *should* be UTF-8, we don't enforce that, so decode
it using the "surrogateescape" scheme to be on the safe-side.